### PR TITLE
Add username parameter to users/fetch

### DIFF
--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -27,14 +27,15 @@ export class UserManager extends BaseManager {
   /**
    * Returns a user's data.
    *
-   * @param users The ids of the users to fetch.
+   * @param users The ids of the users to fetch, or a username string.
    */
-  async fetch(users: number | number[]): Promise<UserResponse> {
-    const ids = typeof users === 'number' ? [users] : users;
+  async fetch(users: string | number | number[]): Promise<UserResponse> {
+    const endpoint =
+      typeof users === 'string'
+        ? Endpoints.users.fetchByUsername(users)
+        : Endpoints.users.fetch(typeof users === 'number' ? [users] : users);
 
-    const response = (await this.request(
-      Endpoints.users.fetch(ids)
-    )) as UserResponse;
+    const response = (await this.request(endpoint)) as UserResponse;
 
     return response;
   }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -9,6 +9,7 @@ const users = {
   auth: (username: string, token: string): string =>
     `/users/auth/?username=${username}&user_token=${token}`,
   fetch: (userIds: number[]): string => `/users/?user_id=${userIds.join()}`,
+  fetchByUsername: (username: string): string => `/users/?username=${username}`,
 };
 
 /**

--- a/test/managers/UserManager.test.ts
+++ b/test/managers/UserManager.test.ts
@@ -72,5 +72,59 @@ describe('UserManager', () => {
         users: [{ id: 15071 }],
       });
     });
+
+    it('should return the correct api response when fetching by user ids', async () => {
+      const userIds = [15071, 20000];
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            response: {
+              success: 'true',
+              users: [
+                {
+                  id: 15071,
+                },
+                {
+                  id: 20000,
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const result = await client.users.fetch(userIds);
+
+      expect(result).toEqual({
+        success: true,
+        users: [{ id: 15071 }, { id: 20000 }],
+      });
+    });
+
+    it('should return the correct api response when fetching by username', async () => {
+      const username = 'testuser';
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            response: {
+              success: 'true',
+              users: [
+                {
+                  id: 15071,
+                  username: 'testuser',
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const result = await client.users.fetch(username);
+
+      expect(result).toEqual({
+        success: true,
+        users: [{ id: 15071, username: 'testuser' }],
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds support for using usernames in the `/users/fetch` request as per the [GameJolt API documentation](https://gamejolt.com/game-api/doc/users/fetch)

Also improved tests coverage for the `UserManager` file